### PR TITLE
Do not create the out-of-band EPG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4 (unreleased)
+
+- Do not create the out-of-band EPG as it overlaps with the `terraform-aci-oob-endpoint-group` module
+
 ## 0.1.3
 
 - Allow pod ID 0 for standalone APICs

--- a/README.md
+++ b/README.md
@@ -60,6 +60,5 @@ module "aci_oob_node_address" {
 
 | Name | Type |
 |------|------|
-| [aci_rest.mgmtOoB](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest) | resource |
 | [aci_rest_managed.mgmtRsOoBStNode](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,24 +1,4 @@
 # Workaround to create out-of-band EPG in case it does not exist yet, but avoid deleting it when the module is destroyed
-resource "aci_rest" "mgmtOoB" {
-  path    = "/api/mo/uni/tn-mgmt/mgmtp-default.json"
-  payload = <<EOF
-    {
-      "mgmtMgmtP": {
-        "attributes": {},
-        "children": [
-          {
-            "mgmtOoB": {
-              "attributes": {
-                "name": "${var.endpoint_group}"
-              }
-            }
-          }
-        ]
-      }
-    }
-  EOF
-}
-
 resource "aci_rest_managed" "mgmtRsOoBStNode" {
   dn         = "uni/tn-mgmt/mgmtp-default/oob-${var.endpoint_group}/rsooBStNode-[topology/pod-${var.pod_id}/node-${var.node_id}]"
   class_name = "mgmtRsOoBStNode"
@@ -29,6 +9,4 @@ resource "aci_rest_managed" "mgmtRsOoBStNode" {
     v6Gw   = var.v6_gateway
     tDn    = "topology/pod-${var.pod_id}/node-${var.node_id}"
   }
-
-  depends_on = [aci_rest.mgmtOoB]
 }


### PR DESCRIPTION
Do not create the out-of-band EPG as it gets created by the `terraform-aci-oob-endpoint-group` module. The out-of-band EPG should already exist prior to executing this module.